### PR TITLE
Updated requirements and added workaround for windows 10

### DIFF
--- a/igd/__main__.py
+++ b/igd/__main__.py
@@ -7,8 +7,7 @@ import socket
 
 from . import core, proto
 
-selector = selectors.DefaultSelector()
-dummy_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
 
 @click.command(
     short_help='Get all port mappings.',
@@ -88,4 +87,7 @@ def main() -> None:
 
 
 if __name__ == '__main__':
+    selector = selectors.DefaultSelector()
+    dummy_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    selector.register(dummy_socket, selectors.EVENT_READ)
     main()

--- a/igd/__main__.py
+++ b/igd/__main__.py
@@ -6,7 +6,9 @@ import selectors
 import socket
 
 from . import core, proto
-
+selector = selectors.DefaultSelector()
+dummy_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+selector.register(dummy_socket, selectors.EVENT_READ)
 
 
 @click.command(
@@ -87,7 +89,4 @@ def main() -> None:
 
 
 if __name__ == '__main__':
-    selector = selectors.DefaultSelector()
-    dummy_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    selector.register(dummy_socket, selectors.EVENT_READ)
     main()

--- a/igd/__main__.py
+++ b/igd/__main__.py
@@ -2,16 +2,20 @@ from typing import Optional
 
 import curio
 import click
+import selectors
+import socket
 
 from . import core, proto
 
+selector = selectors.DefaultSelector()
+dummy_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
 @click.command(
     short_help='Get all port mappings.',
     help='Get all port mappings. Various filtering options available.',
 )
 def ls():
-    port_mapping = curio.run(core.get_port_mappings)
+    port_mapping = curio.run(core.get_port_mappings, selector=selector)
     print(port_mapping)
 
 
@@ -20,7 +24,7 @@ def ls():
     help='Finds Internet Gateway Device and queries for externl IP.',
 )
 def ip():
-    curio.run(core.get_ip)
+    curio.run(core.get_ip, selector=selector)
 
 
 @click.command(
@@ -52,7 +56,7 @@ def add(external_port: int, internal_port: Optional[int], ip: Optional[str],
     mapping = proto.PortMapping(
         '', internal_port, external_port, protocol, ip, True, description,
         duration)
-    curio.run(core.add_port_mapping, mapping)
+    curio.run(core.add_port_mapping, mapping, selector=selector)
 
 
 @click.command(
@@ -67,7 +71,7 @@ def add(external_port: int, internal_port: Optional[int], ip: Optional[str],
                    'allowed.',)
 @click.argument('pattern', type=str, required=True,)
 def rm(pattern: str, protocol: Optional[str]):
-    curio.run(core.delete_port_mappings, pattern, protocol)
+    curio.run(core.delete_port_mappings, pattern, protocol, selector=selector)
 
 
 @click.group()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ def requirements() -> list:
         'curio==0.8',
         'asks==1.3.6',
         'yarl==0.15.0',
-        'lxml==4.1.1',
         'beautifulsoup4==4.6.0',
         'tabulate==0.8.2',
     ]

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ from setuptools import setup, find_packages
 
 def requirements() -> list:
     return [
-        'click==6.7',
-        'curio==0.8',
-        'asks==1.3.6',
-        'yarl==0.15.0',
-        'beautifulsoup4==4.6.0',
-        'tabulate==0.8.2',
+        'click',
+        'curio',
+        'asks',
+        'yarl',
+        'beautifulsoup4',
+        'tabulate',
     ]
 
 


### PR DESCRIPTION
Windows will return immediately when trying to select() on three empty sets, this differs from the POSIX api which will block if given a timeout, this adds a dummy socket to the selectors as shown in dabeaz/curio#75. Also had some issues installing lxml on windows so removed requirement for version 4.1.1
